### PR TITLE
Minor German translation fixes

### DIFF
--- a/public/lang/de.js
+++ b/public/lang/de.js
@@ -77,8 +77,8 @@ export default {
     controls: {
         title: "Ansicht / Steuerung",
         perspective: {
-            button: "Perspectiv-Sicht",
-            tooltip: "Perspectivische Sicht"
+            button: "Perspektiv-Sicht",
+            tooltip: "Perspektivische Sicht"
         },
         flatView: {
             button: "Flache Sicht",
@@ -86,7 +86,7 @@ export default {
         },
         freeFlight: {
             button: "Freie Kamera",
-            tooltip: "Freie Kamera / Beobachter Modus"
+            tooltip: "Freie Kamera / Zuschauermodus"
         }
     },
     language: {


### PR DESCRIPTION
- There was a typo in Perspektive, `k` should be used instead of `c`.
- Spectator mode is called "Zuschauermodus" in Minecraft itself.

:heart: Loving the new frontend