### PR TITLE
Use localStorage instead of cookies to save settings

### DIFF
--- a/src/js/BlueMapApp.js
+++ b/src/js/BlueMapApp.js
@@ -34,7 +34,7 @@ import {MarkerFileManager} from "bluemap/src/markers/MarkerFileManager";
 import {MainMenu} from "@/js/MainMenu";
 import {PopupMarker} from "@/js/PopupMarker";
 import {MarkerSet} from "bluemap/src/markers/MarkerSet";
-import {getCookie, round, setCookie} from "@/js/Utils";
+import {getLocalStorage, round, setLocalStorage} from "@/js/Utils";
 import i18n from "../i18n";
 
 export class BlueMapApp {
@@ -530,7 +530,7 @@ export class BlueMapApp {
     }
 
     loadUserSetting(key, defaultValue){
-        let value = getCookie("bluemap-" + key);
+        let value = getLocalStorage("bluemap-" + key);
 
         if (value === undefined) return defaultValue;
         return value;
@@ -539,7 +539,7 @@ export class BlueMapApp {
     saveUserSetting(key, value){
         if (this.savedUserSettings.get(key) !== value){
             this.savedUserSettings.set(key, value);
-            setCookie("bluemap-" + key, value);
+            setLocalStorage("bluemap-" + key, value);
         }
     }
 

--- a/src/js/Utils.js
+++ b/src/js/Utils.js
@@ -3,8 +3,7 @@
  * localStorage.
  */
 export const setLocalStorage = (key, value) => {
-    localStorage.setItem(key, JSON.stringify(value))
-    value = JSON.stringify(value);
+    localStorage.setItem(key, JSON.stringify(value));
 };
 
 /**
@@ -12,12 +11,12 @@ export const setLocalStorage = (key, value) => {
  * in JSON format, the parsed value will be returned.
  */
 export const getLocalStorage = key => {
-    const value = localStorage.getItem(key)
+    const value = localStorage.getItem(key);
 
     try {
-        return JSON.parse(value)
+        return JSON.parse(value);
     } catch(e) {
-        return value
+        return value;
     }
 };
 

--- a/src/js/Utils.js
+++ b/src/js/Utils.js
@@ -1,40 +1,24 @@
 /**
- * Adapted from https://www.w3schools.com/js/js_cookies.asp
+ * Converts a given value to JSON and writes it to the given key in
+ * localStorage.
  */
-export const setCookie = (key, value, days = 360) => {
+export const setLocalStorage = (key, value) => {
+    localStorage.setItem(key, JSON.stringify(value))
     value = JSON.stringify(value);
-
-    let expireDate = new Date();
-    expireDate.setTime(expireDate.getTime() + days * 24 * 60 * 60 * 1000);
-    document.cookie = key + "=" + value + ";" + "expires=" + expireDate.toUTCString() + ";" + "SameSite=Lax";
 };
 
 /**
- * Adapted from https://www.w3schools.com/js/js_cookies.asp
+ * Fetches the value from a given key from localStorage. If the stored value is
+ * in JSON format, the parsed value will be returned.
  */
-export const getCookie = key => {
-    let cookieString = decodeURIComponent(document.cookie);
-    let cookies = cookieString.split(';');
+export const getLocalStorage = key => {
+    const value = localStorage.getItem(key)
 
-    for(let i = 0; i < cookies.length; i++) {
-        let cookie = cookies[i];
-
-        while (cookie.charAt(0) === ' ') {
-            cookie = cookie.substring(1);
-        }
-
-        if (cookie.indexOf(key + "=") === 0) {
-            let value = cookie.substring(key.length + 1, cookie.length);
-
-            try {
-                value = JSON.parse(value);
-            } catch (e) {} // eslint-disable-line no-empty
-
-            return value;
-        }
+    try {
+        return JSON.parse(value)
+    } catch(e) {
+        return value
     }
-
-    return undefined;
 };
 
 export const round = (value, precision) => {


### PR DESCRIPTION
Using localStorage instead of cookies to save settings avoids unnecessarily sending said cookies to the web server with every request.

Also, localStorage doesn't expire (by itself at least), while cookies do, which doesn't really make sense for persisting local/client-side settings.