### PR TITLE
Fix overscroll on Safari

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -50,6 +50,7 @@ body {
   margin: 0;
   padding: 0;
   overscroll-behavior: none;
+  overflow: hidden;
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Adding the `overscroll: hidden;` property fixes this issue on safari since WebKit does not support `overscroll-behavior: none`

https://user-images.githubusercontent.com/13630061/142778246-62f0d500-9f8f-49cf-9960-4c68e9bc29ee.mp4

